### PR TITLE
Indicate a replacement occurred

### DIFF
--- a/src/applause.js
+++ b/src/applause.js
@@ -160,7 +160,9 @@ Applause.prototype.replace = function (contents, process) {
     var replaced = contents.replace(match, replacement);
     // indicate a replacement occurred
     if (contents !== replaced) {
-      this.options.patterns[i].found = true;
+      if (((this.options || {}).patterns || {})[i]) {
+        this.options.patterns[i].found = true;
+      }
       contents = replaced;
     }
   }.bind(this));

--- a/src/applause.js
+++ b/src/applause.js
@@ -146,7 +146,7 @@ Applause.prototype.replace = function (contents, process) {
   // by default file not updated
   var updated = false;
   // iterate over each pattern and make replacement
-  patterns.forEach(function (pattern) {
+  patterns.forEach(function (pattern, i) {
     var match = pattern.match;
     var replacement = pattern.replacement;
     // wrap replacement function to add process arguments
@@ -157,8 +157,13 @@ Applause.prototype.replace = function (contents, process) {
       };
     }
     updated = updated || contents.match(match);
-    contents = contents.replace(match, replacement);
-  });
+    var replaced = contents.replace(match, replacement);
+    // indicate a replacement occurred
+    if (contents !== replaced) {
+      this.options.patterns[i].found = true;
+      contents = replaced;
+    }
+  }.bind(this));
   if (!updated) {
     return false;
   }


### PR DESCRIPTION
This change tracks whether or not a pattern has been matched in any file. It can later be evaluated by dependents such as https://github.com/outaTiME/grunt-replace