### PR TITLE
Add ability to use suffixes in the match string, e.g. @@env.css.darkStyle@@

### DIFF
--- a/src/applause.js
+++ b/src/applause.js
@@ -90,7 +90,10 @@ var Applause = function (opts) {
     usePrefix: true,
     preservePrefix: false,
     delimiter: '.',
-    preserveOrder: false
+    preserveOrder: false,
+    detail: false,
+    suffix: opts.useSuffix === true ? '@@' : '',
+    useSuffix: false
   });
 };
 
@@ -119,7 +122,7 @@ Applause.prototype.replace = function (content, process) {
         expression = true;
       } else if (_.isString(match)) {
         if (match.length > 0) {
-          match = new RegExp(opts.prefix + escapeRegExp(match), 'g');
+          match = new RegExp(opts.prefix + escapeRegExp(match) + opts.suffix, 'g');
         } else {
           // empty match
           return;
@@ -162,23 +165,23 @@ Applause.prototype.replace = function (content, process) {
       content = content.replace(match, replacement);
       // save detail data
       detail.push({
-        match: match,
-        replacement: replacement,
         source: pattern.source,
         count: count
       });
       total_count += count;
     }
   });
-  // FIXME: always return detailed result
   if (detail.length === 0) {
     content = false;
   }
-  return {
-    content: content,
-    detail: detail,
-    count: total_count
-  };
+  if (opts.detail === true) {
+    return {
+      content: content,
+      detail: detail,
+      count: total_count
+    };
+  }
+  return content;
 };
 
 // static
@@ -187,7 +190,7 @@ Applause.create = function (opts) {
   return new Applause(opts);
 };
 
-Applause.version = require('../package.json').version;
+Applause.VERSION = require('../package.json').version;
 
 // expose
 

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -9,33 +9,189 @@
 
 // dependencies
 
-var path = require('path');
+var _ = require('lodash');
+var plugins = require('./plugins');
 
-// private
+// took from MDN
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 
-// var dir = path.join(__dirname, '/plugins');
+var escapeRegExp = function (string) {
+  return string.replace(/([.*+?^${}()|\[\]\/\\])/g, "\\$1");
+};
 
-var plugins = [
-  require('./plugins/yaml'),
-  require('./plugins/cson'),
-  require('./plugins/json')
-];
-
-// took plugins from folder
-
-/* require('fs').readdirSync(dir).forEach(function (file) {
-  if (file.match(/.+\.js/g) !== null && file !== 'index.js') {
-    var plugin = require(path.join(dir, file));
-    plugins.push(plugin);
+var getPatterns = function (applause) {
+  var opts = applause.options;
+  // shallow patterns
+  var patterns = _.chain(opts.patterns)
+    .clone()
+    .compact()
+    .filter(function (pattern) {
+      return !_.isEmpty(pattern);
+    })
+    .value();
+  // backward compatibility
+  var variables = opts.variables;
+  if (!_.isEmpty(variables)) {
+    patterns.push({
+      json: variables
+    });
   }
-}); */
+  // process
+  for (var i = patterns.length - 1; i >= 0; i -= 1) {
+    var pattern = patterns[i];
+    // plugins
+    plugins.forEach(function (plugin) {
+      if (plugin.match(pattern, opts) === true) {
+        plugin.transform(pattern, opts, function (items) {
+          if (items instanceof Error) {
+            throw items;
+          } else {
+            // store transformed pattern in context
+            pattern = items;
+          }
+        });
+      } else {
+        // plugin doesn't apply
+      }
+    });
+    // convert to array
+    if (!_.isArray(pattern)) {
+      pattern = [pattern];
+    }
+    // link with pattern with original source
+    pattern.forEach(function (pattern) {
+      pattern.source = patterns[i];
+    });
+    // attach index
+    Array.prototype.splice.apply(patterns, [i, 1].concat(pattern));
+  }
+  if (opts.preserveOrder !== true) {
+    // only sort non regex patterns (prevents replace issues like head, header)
+    patterns.sort(function (a, b) {
+      var x = a.match;
+      var y = b.match;
+      if (_.isString(x) && _.isString(y)) {
+        return y.length - x.length;
+      } else if (_.isString(x)) {
+        return -1;
+      }
+      return 1;
+    });
+  }
+  return patterns;
+};
 
-// priority sort
+// applause
 
-plugins.sort(function (a, b) {
-  return (a.priority || 0) - (b.priority || 0);
-});
+var Applause = function (opts) {
+  this.options = _.defaults(opts, {
+    patterns: [],
+    prefix: opts.usePrefix === false ? '' : '@@',
+    usePrefix: true,
+    preservePrefix: false,
+    delimiter: '.',
+    preserveOrder: false,
+    detail: false,
+    suffix: opts.useSuffix === true ? '@@' : '',
+    useSuffix: false
+  });
+};
+
+Applause.prototype.replace = function (content, process) {
+  var opts = this.options;
+  // prevent null
+  content = content || '';
+  // prepare patterns
+  var patterns = getPatterns(this);
+  var detail = [];
+  var total_count = 0;
+  // iterate over each pattern and make replacement
+  patterns.forEach(function (pattern, i) {
+    // filter empty patterns
+    var match = pattern.match;
+    // support replace flag too
+    var replacement = pattern.replacement;
+    if (replacement === undefined || replacement === null) {
+      replacement = pattern.replace;
+    }
+    var source = pattern.source;
+    var expression = false;
+    // match check
+    if (match !== undefined && match !== null) {
+      if (_.isRegExp(match)) {
+        expression = true;
+      } else if (_.isString(match)) {
+        if (match.length > 0) {
+          match = new RegExp(opts.prefix + escapeRegExp(match) + opts.suffix, 'g');
+        } else {
+          // empty match
+          return;
+        }
+      } else {
+        throw new Error('Unsupported match type (RegExp or String expected).');
+      }
+    } else {
+      throw new Error('Match attribute expected in pattern definition.');
+    }
+    // replacement check
+    if (replacement !== undefined && replacement !== null) {
+      if (!_.isFunction(replacement)) {
+        if (!_.isString(replacement)) {
+          // transform object to string
+          replacement = JSON.stringify(replacement);
+        }
+        if (expression === false) {
+          // escape dollar sequences in easy mode
+          replacement = replacement.replace(/\$/g, '$$$');
+          // preserve prefix
+          if (opts.preservePrefix === true) {
+            replacement = opts.prefix + replacement;
+          }
+        }
+      } else {
+        // replace using function return value
+        replacement = function () {
+          var args = Array.prototype.slice.call(arguments);
+          return pattern.replacement.apply(this, args.concat(process || []));
+        };
+      }
+    } else {
+      throw new Error('Replacement attribute expected in pattern definition.');
+    }
+    // replace logic
+    var count = (content.match(match) || []).length;
+    if (count > 0) {
+      // update content
+      content = content.replace(match, replacement);
+      // save detail data
+      detail.push({
+        source: pattern.source,
+        count: count
+      });
+      total_count += count;
+    }
+  });
+  if (detail.length === 0) {
+    content = false;
+  }
+  if (opts.detail === true) {
+    return {
+      content: content,
+      detail: detail,
+      count: total_count
+    };
+  }
+  return content;
+};
+
+// static
+
+Applause.create = function (opts) {
+  return new Applause(opts);
+};
+
+Applause.VERSION = require('../package.json').version;
 
 // expose
 
-module.exports = plugins;
+module.exports = Applause;

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -9,189 +9,33 @@
 
 // dependencies
 
-var _ = require('lodash');
-var plugins = require('./plugins');
+var path = require('path');
 
-// took from MDN
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+// private
 
-var escapeRegExp = function (string) {
-  return string.replace(/([.*+?^${}()|\[\]\/\\])/g, "\\$1");
-};
+// var dir = path.join(__dirname, '/plugins');
 
-var getPatterns = function (applause) {
-  var opts = applause.options;
-  // shallow patterns
-  var patterns = _.chain(opts.patterns)
-    .clone()
-    .compact()
-    .filter(function (pattern) {
-      return !_.isEmpty(pattern);
-    })
-    .value();
-  // backward compatibility
-  var variables = opts.variables;
-  if (!_.isEmpty(variables)) {
-    patterns.push({
-      json: variables
-    });
+var plugins = [
+  require('./plugins/yaml'),
+  require('./plugins/cson'),
+  require('./plugins/json')
+];
+
+// took plugins from folder
+
+/* require('fs').readdirSync(dir).forEach(function (file) {
+  if (file.match(/.+\.js/g) !== null && file !== 'index.js') {
+    var plugin = require(path.join(dir, file));
+    plugins.push(plugin);
   }
-  // process
-  for (var i = patterns.length - 1; i >= 0; i -= 1) {
-    var pattern = patterns[i];
-    // plugins
-    plugins.forEach(function (plugin) {
-      if (plugin.match(pattern, opts) === true) {
-        plugin.transform(pattern, opts, function (items) {
-          if (items instanceof Error) {
-            throw items;
-          } else {
-            // store transformed pattern in context
-            pattern = items;
-          }
-        });
-      } else {
-        // plugin doesn't apply
-      }
-    });
-    // convert to array
-    if (!_.isArray(pattern)) {
-      pattern = [pattern];
-    }
-    // link with pattern with original source
-    pattern.forEach(function (pattern) {
-      pattern.source = patterns[i];
-    });
-    // attach index
-    Array.prototype.splice.apply(patterns, [i, 1].concat(pattern));
-  }
-  if (opts.preserveOrder !== true) {
-    // only sort non regex patterns (prevents replace issues like head, header)
-    patterns.sort(function (a, b) {
-      var x = a.match;
-      var y = b.match;
-      if (_.isString(x) && _.isString(y)) {
-        return y.length - x.length;
-      } else if (_.isString(x)) {
-        return -1;
-      }
-      return 1;
-    });
-  }
-  return patterns;
-};
+}); */
 
-// applause
+// priority sort
 
-var Applause = function (opts) {
-  this.options = _.defaults(opts, {
-    patterns: [],
-    prefix: opts.usePrefix === false ? '' : '@@',
-    usePrefix: true,
-    preservePrefix: false,
-    delimiter: '.',
-    preserveOrder: false,
-    detail: false,
-    suffix: opts.useSuffix === true ? '@@' : '',
-    useSuffix: false
-  });
-};
-
-Applause.prototype.replace = function (content, process) {
-  var opts = this.options;
-  // prevent null
-  content = content || '';
-  // prepare patterns
-  var patterns = getPatterns(this);
-  var detail = [];
-  var total_count = 0;
-  // iterate over each pattern and make replacement
-  patterns.forEach(function (pattern, i) {
-    // filter empty patterns
-    var match = pattern.match;
-    // support replace flag too
-    var replacement = pattern.replacement;
-    if (replacement === undefined || replacement === null) {
-      replacement = pattern.replace;
-    }
-    var source = pattern.source;
-    var expression = false;
-    // match check
-    if (match !== undefined && match !== null) {
-      if (_.isRegExp(match)) {
-        expression = true;
-      } else if (_.isString(match)) {
-        if (match.length > 0) {
-          match = new RegExp(opts.prefix + escapeRegExp(match) + opts.suffix, 'g');
-        } else {
-          // empty match
-          return;
-        }
-      } else {
-        throw new Error('Unsupported match type (RegExp or String expected).');
-      }
-    } else {
-      throw new Error('Match attribute expected in pattern definition.');
-    }
-    // replacement check
-    if (replacement !== undefined && replacement !== null) {
-      if (!_.isFunction(replacement)) {
-        if (!_.isString(replacement)) {
-          // transform object to string
-          replacement = JSON.stringify(replacement);
-        }
-        if (expression === false) {
-          // escape dollar sequences in easy mode
-          replacement = replacement.replace(/\$/g, '$$$');
-          // preserve prefix
-          if (opts.preservePrefix === true) {
-            replacement = opts.prefix + replacement;
-          }
-        }
-      } else {
-        // replace using function return value
-        replacement = function () {
-          var args = Array.prototype.slice.call(arguments);
-          return pattern.replacement.apply(this, args.concat(process || []));
-        };
-      }
-    } else {
-      throw new Error('Replacement attribute expected in pattern definition.');
-    }
-    // replace logic
-    var count = (content.match(match) || []).length;
-    if (count > 0) {
-      // update content
-      content = content.replace(match, replacement);
-      // save detail data
-      detail.push({
-        source: pattern.source,
-        count: count
-      });
-      total_count += count;
-    }
-  });
-  if (detail.length === 0) {
-    content = false;
-  }
-  if (opts.detail === true) {
-    return {
-      content: content,
-      detail: detail,
-      count: total_count
-    };
-  }
-  return content;
-};
-
-// static
-
-Applause.create = function (opts) {
-  return new Applause(opts);
-};
-
-Applause.VERSION = require('../package.json').version;
+plugins.sort(function (a, b) {
+  return (a.priority || 0) - (b.priority || 0);
+});
 
 // expose
 
-module.exports = Applause;
+module.exports = plugins;


### PR DESCRIPTION
Hello, I'm using your library as part of the gulp replace task and find it very useful. It is being added to node_modules via npm install. 
However, I've encountered an issue with using json object pattern matching. 

It's necessary to use suffix sometimes when there are unintended partial matches due to missing json keys in the pattern json object. 
For example, be able to replace matches like @@env.css.darkStyle@@ instead of just @@env.css.darkStyle. This is needed to avoid erroneously substituting a partial match like @@env.css.darkStyle_header with the @@env.css.darkStyle match when darkStyle_header is not found in the pattern json.