### PR TITLE
fix: add type check before accesing String.match

### DIFF
--- a/src/applause.js
+++ b/src/applause.js
@@ -156,7 +156,7 @@ Applause.prototype.replace = function (content, process) {
     }
 
     // Replace logic
-    var count = (content.match(match) || []).length;
+    var count = (typeof content === 'string' && content.match(match) || []).length;
     if (count > 0) {
       // Update content
       content = content.replace(match, replacement);


### PR DESCRIPTION
Added type check for string before calling the `String.prototype.match` method.

Addressing the issue reported in #20 
